### PR TITLE
feat(db): add dual MySQL support with independent connection pools an…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
 
 [[package]]
+name = "enum-iterator"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4549325971814bda7a44061bf3fe7e487d447cba01e4220a4b454d630d7a016"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "enumflags2"
 version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2321,6 +2341,7 @@ dependencies = [
  "log",
  "rayon",
  "rfd",
+ "rphonetic",
  "rust_xlsxwriter",
  "serde",
  "sqlx",
@@ -2389,6 +2410,15 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "ntapi"
@@ -3262,6 +3292,21 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rphonetic"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30ef212c21841bb9c0ad2fcc9f7a7b8aadb77ed412e8c5d0d5663b83c4a388b"
+dependencies = [
+ "document-features",
+ "either",
+ "enum-iterator",
+ "lazy_static",
+ "nom",
+ "regex",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ env_logger = "0.11.8"
 log = "0.4.28"
 rayon = "1.11.0"
 rfd = "0.15.4"
+rphonetic = "3.0.4"
 rust_xlsxwriter = "0.90.1"
 serde = { version = "1.0.225", features = ["derive"] }
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "mysql", "chrono", "uuid"] }

--- a/src/db/connection.rs
+++ b/src/db/connection.rs
@@ -2,6 +2,7 @@ use crate::config::DatabaseConfig;
 use anyhow::Result;
 use sqlx::mysql::MySqlPoolOptions;
 use sqlx::MySqlPool;
+use std::time::Duration;
 
 pub async fn make_pool(cfg: &DatabaseConfig) -> Result<MySqlPool> {
     make_pool_with_size(cfg, None).await
@@ -11,9 +12,18 @@ pub async fn make_pool_with_size(cfg: &DatabaseConfig, max: Option<u32>) -> Resu
     let url = cfg.to_url();
     let max_conn = max
         .or_else(|| std::env::var("NAME_MATCHER_POOL_SIZE").ok().and_then(|s| s.parse().ok()))
-        .unwrap_or(10);
+        .unwrap_or(16);
+    let min_conn: u32 = std::env::var("NAME_MATCHER_POOL_MIN").ok().and_then(|s| s.parse().ok()).unwrap_or(4);
+    let acquire_ms: u64 = std::env::var("NAME_MATCHER_ACQUIRE_MS").ok().and_then(|s| s.parse().ok()).unwrap_or(30_000);
+    let idle_ms: u64 = std::env::var("NAME_MATCHER_IDLE_MS").ok().and_then(|s| s.parse().ok()).unwrap_or(60_000);
+    let life_ms: u64 = std::env::var("NAME_MATCHER_LIFETIME_MS").ok().and_then(|s| s.parse().ok()).unwrap_or(600_000);
+
     let pool = MySqlPoolOptions::new()
         .max_connections(max_conn)
+        .min_connections(min_conn)
+        .acquire_timeout(Duration::from_millis(acquire_ms))
+        .idle_timeout(Some(Duration::from_millis(idle_ms)))
+        .max_lifetime(Some(Duration::from_millis(life_ms)))
         .connect(&url)
         .await?;
     Ok(pool)

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -1,7 +1,24 @@
 use anyhow::{bail, Context, Result};
 use sqlx::{MySql, MySqlPool, Row};
 
-use crate::models::{Person, TableColumns};
+use crate::models::{Person, TableColumns, ColumnMapping};
+
+#[derive(Debug, Clone)]
+pub enum SqlBind { I64(i64), Str(String) }
+
+fn build_select_list(mapping: Option<&ColumnMapping>) -> Result<String> {
+    // Validate identifiers to prevent injection; when None, use defaults
+    let m = mapping.cloned().unwrap_or_default();
+    // Validate each column ident when provided
+    fn val(id: &str) -> Result<()> { super::schema::validate_ident(id) }
+    val(&m.id)?; val(&m.uuid)?; val(&m.first_name)?; val(&m.last_name)?; val(&m.birthdate)?;
+    if let Some(ref mid) = m.middle_name { val(mid)?; }
+    let mid_sql = if let Some(mid) = m.middle_name.as_ref() { format!("`{}` AS middle_name", mid) } else { "NULL AS middle_name".to_string() };
+    Ok(format!(
+        "`{id}` AS id, `{uuid}` AS uuid, `{first}` AS first_name, {mid}, `{last}` AS last_name, DATE(`{bd}`) AS birthdate",
+        id = m.id, uuid = m.uuid, first = m.first_name, mid = mid_sql, last = m.last_name, bd = m.birthdate
+    ))
+}
 
 fn validate_ident(name: &str) -> Result<()> {
     if name.is_empty() || !name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_' ) {
@@ -69,6 +86,52 @@ pub async fn get_person_count(pool: &MySqlPool, table: &str) -> Result<i64> {
     let row = sqlx::query(&sql).fetch_one(pool).await?;
     let cnt: i64 = row.try_get("cnt")?;
     Ok(cnt)
+}
+
+
+// --- Flexible/mapped selection helpers and WHERE-aware fetchers ---
+pub async fn get_person_rows_mapped(pool: &MySqlPool, table: &str, mapping: Option<&ColumnMapping>) -> Result<Vec<Person>> {
+    super::schema::validate_ident(table)?;
+    let select = build_select_list(mapping)?;
+    let sql = format!("SELECT {select} FROM `{table}`", select=select, table=table);
+    let rows: Vec<Person> = sqlx::query_as::<MySql, Person>(&sql)
+        .fetch_all(pool)
+        .await
+        .with_context(|| format!("Failed to fetch rows from {} (mapped)", table))?;
+    Ok(rows)
+}
+
+pub async fn get_person_count_where(pool: &MySqlPool, table: &str, where_sql: &str, binds: &[SqlBind]) -> Result<i64> {
+    super::schema::validate_ident(table)?;
+    let sql = format!("SELECT COUNT(*) as cnt FROM `{}` WHERE {}", table, where_sql);
+    let mut q = sqlx::query(&sql);
+    for b in binds {
+        q = match b { SqlBind::I64(v) => q.bind(*v), SqlBind::Str(s) => q.bind(s) };
+    }
+    let row = q.fetch_one(pool).await?;
+    let cnt: i64 = row.try_get("cnt")?;
+    Ok(cnt)
+}
+
+pub async fn get_person_rows_where(pool: &MySqlPool, table: &str, where_sql: &str, binds: &[SqlBind], mapping: Option<&ColumnMapping>) -> Result<Vec<Person>> {
+    super::schema::validate_ident(table)?;
+    let select = build_select_list(mapping)?;
+    let sql = format!("SELECT {select} FROM `{table}` WHERE {where}", select=select, table=table, where=where_sql);
+    let mut q = sqlx::query_as::<MySql, Person>(&sql);
+    for b in binds { q = match b { SqlBind::I64(v) => q.bind(*v), SqlBind::Str(s) => q.bind(s) }; }
+    let rows = q.fetch_all(pool).await.with_context(|| format!("Failed to fetch rows from {} with filter", table))?;
+    Ok(rows)
+}
+
+pub async fn fetch_person_rows_chunk_where(pool: &MySqlPool, table: &str, offset: i64, limit: i64, where_sql: &str, binds: &[SqlBind], mapping: Option<&ColumnMapping>) -> Result<Vec<Person>> {
+    super::schema::validate_ident(table)?;
+    let select = build_select_list(mapping)?;
+    let sql = format!("SELECT {select} FROM `{table}` WHERE {where} ORDER BY id LIMIT ? OFFSET ?", select=select, table=table, where=where_sql);
+    let mut q = sqlx::query_as::<MySql, Person>(&sql);
+    for b in binds { q = match b { SqlBind::I64(v) => q.bind(*v), SqlBind::Str(s) => q.bind(s) }; }
+    let rows: Vec<Person> = q.bind(limit).bind(offset).fetch_all(pool).await
+        .with_context(|| format!("Failed to fetch chunk from {} (offset {}, limit {}) with filter", table, offset, limit))?;
+    Ok(rows)
 }
 
 pub async fn fetch_person_rows_chunk(pool: &MySqlPool, table: &str, offset: i64, limit: i64) -> Result<Vec<Person>> {

--- a/src/export/csv_export.rs
+++ b/src/export/csv_export.rs
@@ -71,6 +71,10 @@ fn write_pair(w: &mut Writer<std::fs::File>, pair: &MatchPair, algorithm: Matchi
             ])?;
         }
         MatchingAlgorithm::Fuzzy => {
+            if pair.confidence < 0.95 {
+                // Skip writing fuzzy matches below 95% per new requirement
+                return Ok(());
+            }
             w.write_record(&[
                 pair.person1.id.to_string(),
                 pair.person1.uuid.clone(),
@@ -105,5 +109,6 @@ impl CsvStreamWriter {
         Ok(Self { writer, algo: algorithm })
     }
     pub fn write(&mut self, pair: &MatchPair) -> Result<()> { write_pair(&mut self.writer, pair, self.algo) }
+    pub fn flush_partial(&mut self) -> Result<()> { self.writer.flush()?; Ok(()) }
     pub fn flush(mut self) -> Result<()> { self.writer.flush()?; Ok(()) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,4 +5,5 @@ pub mod matching;
 pub mod models;
 pub mod normalize;
 pub mod metrics;
+pub mod util;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -41,3 +41,25 @@ impl TableColumns {
     }
 }
 
+// Column mapping for flexible schemas; map source column names to expected aliases.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ColumnMapping {
+    pub id: String,
+    pub uuid: String,
+    pub first_name: String,
+    pub middle_name: Option<String>,
+    pub last_name: String,
+    pub birthdate: String,
+}
+
+impl Default for ColumnMapping {
+    fn default() -> Self {
+        Self { id: "id".into(), uuid: "uuid".into(), first_name: "first_name".into(), middle_name: Some("middle_name".into()), last_name: "last_name".into(), birthdate: "birthdate".into() }
+    }
+}
+
+impl ColumnMapping {
+    pub fn required_ok(&self) -> bool {
+        !self.id.is_empty() && !self.uuid.is_empty() && !self.first_name.is_empty() && !self.last_name.is_empty() && !self.birthdate.is_empty()
+    }
+}

--- a/src/util/checkpoint.rs
+++ b/src/util/checkpoint.rs
@@ -1,0 +1,87 @@
+use std::{fs, path::Path};
+
+#[derive(Debug, Clone)]
+pub struct StreamCheckpoint {
+    pub db: String,
+    pub table_inner: String,
+    pub table_outer: String,
+    pub algorithm: String,
+    pub batch_size: i64,
+    pub next_offset: i64,
+    pub total_outer: i64,
+    pub partition_idx: i32,
+    pub partition_name: String,
+    pub updated_utc: String,
+}
+
+impl StreamCheckpoint {
+    fn serialize(&self) -> String {
+        format!(
+            "db={}\ninner={}\nouter={}\nalgo={}\nbatch={}\noffset={}\ntotal={}\npart_idx={}\npart_name={}\nupdated={}\n",
+            self.db,
+            self.table_inner,
+            self.table_outer,
+            self.algorithm,
+            self.batch_size,
+            self.next_offset,
+            self.total_outer,
+            self.partition_idx,
+            self.partition_name,
+            self.updated_utc
+        )
+    }
+    fn deserialize(s: &str) -> Option<Self> {
+        let mut db = String::new();
+        let mut inner = String::new();
+        let mut outer = String::new();
+        let mut algo = String::new();
+        let mut batch = 0i64;
+        let mut offset = 0i64;
+        let mut total = 0i64;
+        let mut part_idx = 0i32;
+        let mut part_name = String::new();
+        let mut updated = String::new();
+        for line in s.lines() {
+            if let Some((k,v)) = line.split_once('=') {
+                match k {
+                    "db" => db = v.to_string(),
+                    "inner" => inner = v.to_string(),
+                    "outer" => outer = v.to_string(),
+                    "algo" => algo = v.to_string(),
+                    "batch" => batch = v.parse().unwrap_or(0),
+                    "offset" => offset = v.parse().unwrap_or(0),
+                    "total" => total = v.parse().unwrap_or(0),
+                    "part_idx" => part_idx = v.parse().unwrap_or(0),
+                    "part_name" => part_name = v.to_string(),
+                    "updated" => updated = v.to_string(),
+                    _ => {}
+                }
+            }
+        }
+        if db.is_empty() || inner.is_empty() || outer.is_empty() || algo.is_empty() { return None; }
+        Some(Self { db, table_inner: inner, table_outer: outer, algorithm: algo, batch_size: batch, next_offset: offset, total_outer: total, partition_idx: part_idx, partition_name: part_name, updated_utc: updated })
+    }
+}
+
+pub fn load_checkpoint(path: &str) -> Option<StreamCheckpoint> {
+    if !Path::new(path).exists() { return None; }
+    match fs::read_to_string(path) {
+        Ok(s) => StreamCheckpoint::deserialize(&s),
+        Err(_) => None,
+    }
+}
+
+pub fn save_checkpoint(path: &str, cp: &StreamCheckpoint) -> std::io::Result<()> {
+    if let Some(parent) = Path::new(path).parent() { let _ = fs::create_dir_all(parent); }
+    let s = cp.serialize();
+    // write atomically: write to tmp then rename
+    let tmp = format!("{}.tmp", path);
+    fs::write(&tmp, s.as_bytes())?;
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+pub fn remove_checkpoint(path: &str) {
+    let _ = fs::remove_file(path);
+}
+

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,2 @@
+pub mod checkpoint;
+pub mod partition;

--- a/src/util/partition.rs
+++ b/src/util/partition.rs
@@ -1,0 +1,80 @@
+use crate::db::schema::SqlBind;
+use crate::models::ColumnMapping;
+
+#[derive(Debug, Clone)]
+pub struct Partition {
+    pub name: String,
+    pub where_sql: String,
+    pub binds: Vec<SqlBind>,
+}
+
+pub trait PartitionStrategy {
+    fn partitions(&self, mapping: Option<&ColumnMapping>) -> Vec<Partition>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LastInitial; // A-Z plus non-alpha bucket
+
+impl PartitionStrategy for LastInitial {
+    fn partitions(&self, mapping: Option<&ColumnMapping>) -> Vec<Partition> {
+        let m = mapping.cloned().unwrap_or_default();
+        let last = m.last_name;
+        let mut parts = Vec::with_capacity(27);
+        for ch in b'A'..=b'Z' {
+            let c = ch as char;
+            parts.push(Partition {
+                name: format!("last_{}", c),
+                where_sql: format!("UPPER(LEFT(`{}`,1)) = ?", last),
+                binds: vec![SqlBind::Str(c.to_string())],
+            });
+        }
+        // Non-alpha bucket
+        parts.push(Partition {
+            name: "last_other".into(),
+            where_sql: format!("NOT (UPPER(LEFT(`{}`,1)) BETWEEN 'A' AND 'Z')", last),
+            binds: vec![],
+        });
+        parts
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BirthYearRanges { pub years_per_shard: i32, pub min_year: i32, pub max_year: i32 }
+
+impl Default for BirthYearRanges {
+    fn default() -> Self { Self { years_per_shard: 5, min_year: 1900, max_year: 2030 } }
+}
+
+impl PartitionStrategy for BirthYearRanges {
+    fn partitions(&self, mapping: Option<&ColumnMapping>) -> Vec<Partition> {
+        let m = mapping.cloned().unwrap_or_default();
+        let bd = m.birthdate;
+        let mut v = Vec::new();
+        let mut y = self.min_year;
+        while y <= self.max_year {
+            let y2 = (y + self.years_per_shard - 1).min(self.max_year);
+            v.push(Partition {
+                name: format!("year_{}_{}", y, y2),
+                where_sql: format!("YEAR(`{}`) BETWEEN ? AND ?", bd),
+                binds: vec![SqlBind::I64(y as i64), SqlBind::I64(y2 as i64)],
+            });
+            y += self.years_per_shard;
+        }
+        v
+    }
+}
+
+pub enum DefaultPartition {
+    LastInitial,
+    BirthYear5,
+}
+
+impl DefaultPartition {
+    pub fn build(&self) -> Box<dyn PartitionStrategy + Send + Sync> {
+        match self {
+            DefaultPartition::LastInitial => Box::new(LastInitial),
+            DefaultPartition::BirthYear5 => Box::new(BirthYearRanges::default()),
+        }
+    }
+}
+


### PR DESCRIPTION
…d cross-database streaming\n\n- Introduce optional DB2_* environment variables for second database\n- Create separate pools (pool1/pool2) and use them across discovery, counts, and streaming\n- Add stream_match_csv_dual() for cross-database streaming with checkpoint/resume and progress\n- Preserve single-DB behavior and partitioned streaming for back-compat\n- Update CSV/XLSX streaming paths to use dual-pool when provided\n\nNote: GUI updates to expose dual DB inputs can follow; single-DB UX unchanged.\nTests: Build succeeds; added wiring ready for external DB tests (env-driven).